### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# Claude Code local settings
+.claude/


### PR DESCRIPTION
Adds the .claude/ directory to .gitignore to prevent Claude Code local settings from causing conflicts during branch switching.