### PR TITLE
🔧 Fix broken hero image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 <div align="center">
-  <img src=".github/assets/expense-tracker-hero.png" alt="ExpenseTracker App" width="600">
   
-  # 💰 ExpenseTracker-SwiftUI
-  
-  **A modern SwiftUI expense tracking app built with SwiftData and Swift Charts**
-  
-  Track your spending with beautiful visualizations, smart filtering, and comprehensive category management.
+# 💰 ExpenseTracker-SwiftUI
 
-  ![iOS 18.0+](https://img.shields.io/badge/iOS-18.0+-blue.svg)
-  ![SwiftUI](https://img.shields.io/badge/SwiftUI-5.0-orange.svg)
-  ![SwiftData](https://img.shields.io/badge/SwiftData-iOS18-green.svg)
-  ![Swift Charts](https://img.shields.io/badge/Swift_Charts-5.0-red.svg)
+**A modern SwiftUI expense tracking app built with SwiftData and Swift Charts**
+
+Track your spending with beautiful visualizations, smart filtering, and comprehensive category management.
+
+![iOS 18.0+](https://img.shields.io/badge/iOS-18.0+-blue.svg)
+![SwiftUI](https://img.shields.io/badge/SwiftUI-5.0-orange.svg)
+![SwiftData](https://img.shields.io/badge/SwiftData-iOS18-green.svg)
+![Swift Charts](https://img.shields.io/badge/Swift_Charts-5.0-red.svg)
+
 </div>
+
+<!-- 
+Hero artwork placeholder - to add artwork:
+1. Save your artwork image as `.github/assets/expense-tracker-hero.png`
+2. Uncomment the line below:
+<img src=".github/assets/expense-tracker-hero.png" alt="ExpenseTracker App" width="600">
+-->
 
 ## ✨ Features
 


### PR DESCRIPTION
## Problem
The README was referencing a hero image at `.github/assets/expense-tracker-hero.png` that doesn't exist in the repository, causing a broken image display on the main page.

## Solution
- ✅ **Removed broken image reference** to fix immediate display issue
- ✅ **Preserved clean centered header design** with title and badges
- ✅ **Added commented placeholder** with clear instructions for adding artwork
- ✅ **Maintained all existing content** and formatting

## Next Steps
To add the hero artwork:
1. Save the artwork image as `.github/assets/expense-tracker-hero.png`
2. Uncomment the image tag in the README

## Result
- ✅ README now displays properly without broken images
- ✅ Clean, professional header maintained
- ✅ Easy path forward for adding artwork when ready