### PR TITLE
Add instructions/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ xcuserdata/
 .env.local
 .envrc
 
+# Instructions directory (contains project documentation/notes)
+instructions/
+
 # --- Xcode Build Products ---
 DerivedData/
 build/


### PR DESCRIPTION
The instructions/ directory, which contains project documentation and notes, is now ignored to prevent accidental commits of local documentation files.