### PR TITLE
chore: fix malformed ios-ci.yml workflow file

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,4 +1,32 @@
-git add .github/workflows/ios-ci.yml
-git commit -m "ci: add GitHub Actions workflow for iOS build and tests"
-git push -u origin feature/ci-setup
+name: iOS CI
 
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Show Xcode version
+      run: xcodebuild -version
+      
+    - name: Build project
+      run: |
+        xcodebuild -project ExpenseTracker.xcodeproj \
+                   -scheme ExpenseTracker \
+                   -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
+                   build
+    
+    - name: Run tests
+      run: |
+        xcodebuild -project ExpenseTracker.xcodeproj \
+                   -scheme ExpenseTracker \
+                   -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
+                   test


### PR DESCRIPTION
## Summary
- Fixed ios-ci.yml workflow file that contained git commands instead of proper YAML
- Replaced with clean iOS CI workflow using xcodebuild
- Removed problematic Xcode path selection step

## Test plan
- [x] Push triggers CI workflow
- [ ] Verify workflow runs successfully in Actions tab